### PR TITLE
New Candidate button

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,24 @@ class DemoApp < Sinatra::Base
     erb :index, layout: :layout
   end
 
+  get '/new_candidate' do
+    response = HTTParty.post(ENV['CHECKR_API'] + '/v1/candidates',
+      basic_auth: { username: session["access_token"], password: nil },
+      body: {
+        first_name:             'Your',
+        middle_name:            'Full',
+        last_name:              'Name',
+        email:                  'your.name@example.com',
+        phone:                  '5555555555',
+        zipcode:                '90401',
+        dob:                    '1970-01-22',
+        ssn:                    '111-11-2001',
+        driver_license_number:  'F1112001',
+        driver_license_state:   'CA'
+      }
+    )
+  end
+
   get '/oauth_callback' do
     code = params[:code]
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -26,6 +26,8 @@
 <% if @candidates %>
   <div class='row'>
     <div class="col-md-12">
+      <a href="/new_candidate" class="btn btn-success pull-right">Create Test Candidate</a>
+
       <h3>Candidates</h3>
       <table class="table table-striped">
         <thead>


### PR DESCRIPTION
Allows us to create new candidates, which is helpful for demonstration purposes

Working on this exposed the auth token bug we have in Oauth Test mode: https://trello.com/c/tmjlLycH/39-product-fix-warden-auth-strategy-for-oauth-test-tokens
