### PR TITLE
Small fix of .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 CHECKR_API_URL='https://api.checkr.com'
-CHECKR_OAUTH_URL='https://dashboard.checkr.com/oauth/authorize'
+CHECKR_OAUTH_URL='https://partners.checkr.com/authorize'
 CHECKR_CLIENT_ID=''
 CHECKR_CLIENT_SECRET=''
 REDIRECT_URI=''

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ This repository contains a sample app that demonstrates OAuth integration as wel
 ### Setup
 `bundle install`
 
-#### Set values for constants in `.env`:
-* `CHECKR_CLIENT_ID='your client id'`
-* `CHECKR_CLIENT_SECRET='your secret key'`
-* `REDIRECT_URI='https://your-domain.com/oauth_callback'`
+#### Set environment variables
+
+* Copy `.env.example` to `.env`
+* Set variables as:
+  * `CHECKR_CLIENT_ID='your client id'`
+  * `CHECKR_CLIENT_SECRET='your secret key'`
+  * `REDIRECT_URI='https://your-domain.com/oauth_callback'`
 
 ### Start webserver
 `foreman start web`


### PR DESCRIPTION
- Move `.env` to `.env.example`
- Use service `partners` in `.env.example`
- Fixes Readme instructions